### PR TITLE
添加响应类，代替Map的返回信息

### DIFF
--- a/src/main/java/com/newxton/nxtframework/controller/api/admin/NxtApiAdminProductBrandDeleteController.java
+++ b/src/main/java/com/newxton/nxtframework/controller/api/admin/NxtApiAdminProductBrandDeleteController.java
@@ -3,13 +3,13 @@ package com.newxton.nxtframework.controller.api.admin;
 import com.alibaba.fastjson.JSONObject;
 import com.newxton.nxtframework.entity.NxtProduct;
 import com.newxton.nxtframework.entity.NxtProductBrand;
+import com.newxton.nxtframework.entity.R;
+import com.newxton.nxtframework.enums.RStatus;
 import com.newxton.nxtframework.service.NxtProductBrandService;
 import com.newxton.nxtframework.service.NxtProductService;
 import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Resource;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author soyojo.earth@gmail.com
@@ -26,26 +26,18 @@ public class NxtApiAdminProductBrandDeleteController {
     private NxtProductService nxtProductService;
 
     @RequestMapping(value = "/api/admin/product_brand/delete", method = RequestMethod.POST)
-    public Map<String, Object> index(@RequestBody JSONObject jsonParam) {
+    public R<String> index(@RequestBody JSONObject jsonParam) {
 
         Long id = jsonParam.getLong("id");
 
-        Map<String, Object> result = new HashMap<>();
-        result.put("status", 0);
-        result.put("message", "");
-
         if (id == null) {
-            result.put("status", 52);
-            result.put("message", "参数错误");
-            return result;
+            return R.error(RStatus.ERROR_PARAM);
         }
 
         /*先查询*/
         NxtProductBrand content = nxtProductBrandService.queryById(id);
-        if (content == null){
-            result.put("status", 49);
-            result.put("message", "找不到对应的内容");
-            return result;
+        if (content == null) {
+            return R.error(RStatus.NO_CONTENT);
         }
 
         //检查冲突
@@ -54,15 +46,13 @@ public class NxtApiAdminProductBrandDeleteController {
 
         Long count = nxtProductService.queryCount(nxtProductCondition);
 
-        if (count > 0){
-            result.put("status", 55);
-            result.put("message", "该品牌已被产品引用，请先取消引用");
-            return result;
+        if (count > 0) {
+            return R.error(RStatus.QUOTE_IN_ADVANCE);
         }
 
         nxtProductBrandService.deleteById(content.getId());
 
-        return result;
+        return R.ok();
 
     }
 

--- a/src/main/java/com/newxton/nxtframework/entity/R.java
+++ b/src/main/java/com/newxton/nxtframework/entity/R.java
@@ -1,0 +1,66 @@
+package com.newxton.nxtframework.entity;
+
+
+import com.newxton.nxtframework.enums.RStatus;
+
+/**
+ * 通用返回类
+ * 可以代替后台返回Map有2大好处
+ * 1. 可以节省代码，使用error，ok等静态方法快速构造返回内容,一行可以顶替1-3行，效果可观
+ * 2. 可以使得返回内容更加清晰，即使不阅读方法内容，也可以知道方法具体的返回类型
+ *
+ * @param <T>
+ */
+public class R<T> {
+
+    private Integer status;
+    private String message;
+    private T result;
+
+
+    public static <T> R<T> error(RStatus e) {
+        R<T> r = new R<>();
+        r.setMessage(e.getMessage());
+        r.setStatus(e.getStatus());
+        return r;
+    }
+
+    public static <T> R<T> ok(T data) {
+        R<T> r = new R<>();
+        r.setMessage(RStatus.SUCCESS.getMessage());
+        r.setStatus(RStatus.SUCCESS.getStatus());
+        r.setResult(data);
+        return r;
+    }
+
+    public static <T> R<T> ok() {
+        R<T> r = new R<>();
+        r.setMessage(RStatus.SUCCESS.getMessage());
+        r.setStatus(RStatus.SUCCESS.getStatus());
+        return r;
+    }
+
+    public T getResult() {
+        return result;
+    }
+
+    public void setResult(T result) {
+        this.result = result;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/newxton/nxtframework/enums/RStatus.java
+++ b/src/main/java/com/newxton/nxtframework/enums/RStatus.java
@@ -1,0 +1,54 @@
+package com.newxton.nxtframework.enums;
+
+/**
+ * 错误状态的枚举类
+ *
+ * @author qiqi.chen
+ */
+public enum RStatus {
+
+    /**
+     * 通用的参数错误
+     */
+    ERROR_PARAM(52, "参数错误"),
+
+    /**
+     * 成功
+     */
+    SUCCESS(0, ""),
+
+    /**
+     * 无内容
+     */
+    NO_CONTENT(49, "找不到对应的内容"),
+
+    /**
+     * 提前引用
+     */
+    QUOTE_IN_ADVANCE(55, "该品牌已被产品引用，请先取消引用");
+
+
+    private Integer status;
+    private String message;
+
+    RStatus(Integer status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}


### PR DESCRIPTION
添加通用返回类
 * 可以代替后台返回Map有2大好处
 * 1. 可以节省代码，使用error，ok等静态方法快速构造返回内容,一行可以顶替1-3行，效果可观
 * 2. 可以使得返回内容更加清晰，即使不阅读方法内容，也可以知道方法具体的返回类型

与通用返回类，配套的还有RStatus枚举类，使用该类，可以将所有的异常码集中起来，方便统一处理，国际化等